### PR TITLE
Reference page updates for Atomizer 3.0

### DIFF
--- a/app/components/Reference.jsx
+++ b/app/components/Reference.jsx
@@ -8,6 +8,7 @@ var Rules = require('atomizer/src/rules');
 var SearchBox = require('./SearchBox');
 var ConfigBox = require('./ConfigBox');
 var ReferenceRules = require('./ReferenceRules');
+var ReferenceHelpers = require('./ReferenceHelpers');
 var AtomicCssOutputBox = require('./AtomicCssOutputBox');
 
 // stores
@@ -50,7 +51,10 @@ var Reference = React.createClass({
         return (
             <div>
                 <SearchBox />
+                <h2>Atomic Classes</h2>
                 <ReferenceRules />
+                <h2>Helper Classes</h2>
+                <ReferenceHelpers />
                 <AtomicCssOutputBox className={hasConfig ? '' : 'D(n)'} />
             </div>
         );

--- a/app/components/ReferenceHelpers.jsx
+++ b/app/components/ReferenceHelpers.jsx
@@ -1,0 +1,139 @@
+/**
+ * Copyright 2015, Yahoo Inc.
+ * Copyrights licensed under the New BSD License. See the accompanying LICENSE file for terms.
+ */
+'use strict';
+
+var escapeStringRegexp = require('escape-string-regexp');
+
+var React = require('react');
+var Rules = require('atomizer/src/helpers');
+var Atomizer = require('atomizer');
+
+// stores
+var ReferenceStore = require('../stores/ReferenceStore');
+
+// mixins
+var FluxibleMixin = require('fluxible').Mixin;
+
+var atomizer = new Atomizer();
+
+/**
+ * Reference docs for the helper ruleset
+ *
+ * @class ReferenceHelpers
+ * @constructor
+ */
+var ReferenceRules = React.createClass({
+    mixins: [FluxibleMixin],
+    statics: {
+        storeListeners: [ReferenceStore]
+    },
+
+    getInitialState: function () {
+        this.store = this.getStore(ReferenceStore);
+        return this.store.getState();
+    },
+
+    onChange: function () {
+        var state = this.store.getState();
+        this.setState(state);
+    },
+
+    hasClassUsingPrefix: function (prefix, classnames) {
+        var value;
+        for (var i=0, iLen=classnames.length; iLen; i++) {
+            value = classnames[i];
+            if (value.indexOf(prefix) === 0) { return true; }
+        }
+        return false;
+    },
+
+    /**
+     * Refer to React documentation render
+     *
+     * @method render
+     * @return {Object} HTML head section
+     */
+    render: function () {
+        var searchRE = false;
+        if (this.state.currentQuery) {
+            var escapedString = escapeStringRegexp(this.state.currentQuery);
+            searchRE = new RegExp(escapedString, 'i');
+        } 
+        var customConfig = this.state.customConfigObj;
+        var hasConfig = !!customConfig;
+
+        if (!hasConfig) {
+            customConfig = {};
+        }
+
+        var items = Rules.map(function (recipe) {
+            var usingClass = false,
+                values = [],
+                classDefinitions = [],
+                declarationBlock,
+                searching = !!this.state.currentQuery,
+                searchTitleMatches = null,
+                showRecipeBlock = false,
+                custom,
+                value,
+                suffix;
+
+            if (customConfig.classNames && customConfig.classNames.length) {
+                usingClass = this.hasClassUsingPrefix(recipe.prefix, customConfig.classNames);
+            }
+
+            // If config is provided, filter any rules not used in config
+            if (hasConfig && !usingClass) {
+                return;
+            }
+
+            if (searching) {
+                searchTitleMatches = (recipe.name.search(searchRE) > -1);
+            }
+
+            if (recipe.type === 'helper') {
+                declarationBlock = [];
+                for (var selector in recipe.rules) {
+                    var showRuleset = false;
+                    var declarationObj = recipe.rules[selector];
+                    var rawDeclarationBlock = [];
+                    var styledDeclarationBlock = [];
+
+                    for (var property in declarationObj) {
+                        rawDeclarationBlock.push(property + ": " + declarationObj[property] + ";");
+                        styledDeclarationBlock.push(<div>{property}: {declarationObj[property]};</div>);
+                    }
+
+                    // Filter with search
+                    if (!searching || 
+                            searchTitleMatches || 
+                            selector.search(searchRE) > -1 || 
+                            rawDeclarationBlock.join('\n').search(searchRE) > -1) {
+                        showRuleset = true;
+                        showRecipeBlock = true;
+                    }
+                    classDefinitions.push([<dt className={showRuleset ? 'Pend(10px) Fl(start) Cl(start)' : 'D(n)'}>{selector}</dt>, <dd className={showRuleset ? 'Ov(h) M(0) P(0) C(#f2438c)' : 'D(n)'}>{styledDeclarationBlock}</dd>]);
+                }
+            }
+
+            var displayclassDefinitions = "Va(t) W(50%)--sm " + (showRecipeBlock ? "D(ib)--sm" : "D(n)");
+            return (
+                <div key={'id-' + recipe.prefix} className={displayclassDefinitions}>
+                    <h3 className="M(0) Mt(10px) P(10px)">{recipe.name}</h3>
+                    <dl className="M(0) P(10px) Pt(0) Pend(50px)--sm Ff(m)">{classDefinitions}</dl>
+                </div>
+            );
+
+        }, this);
+
+        return (
+            <div>
+                {items}
+            </div>
+        );
+    }
+});
+
+module.exports = ReferenceRules;

--- a/package.json
+++ b/package.json
@@ -27,9 +27,10 @@
     "lint"
   ],
   "dependencies": {
-    "atomizer": "^2.0.0-beta.9",
+    "atomizer": "^3.0.0-alpha",
     "body-parser": "^1.9.3",
     "debug": "^2.1.1",
+    "escape-string-regexp": "^1.0.0",
     "express": "^4.10.4",
     "express-state": "^1.2.0",
     "flux-router-component": "~0.5.0",


### PR DESCRIPTION
I've updated the syntax for Atomizer 3.0, and also fixed some issues with searching and helper display.  Also clarified when rules allow suffix-to-value and custom suffixes/values, but please offer feedback on whether the wording or styling could be better (I personally think it's not quite clear enough.)

I'll continue working on the reference page to bring back the custom config box.  Note that there are some changes here toward that goal, but are incomplete or rough around the edges.  I'll be fixing that stuff up, but wanted to get the new syntax support out the door quickly.

fyi @renatoi @thierryk 