### PR TITLE
Updating dependency on Atomizer to use ^

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "lint"
   ],
   "dependencies": {
-    "atomizer": "3.0.0",
+    "atomizer": "^3.1.0",
     "babel": "^4.7.8",
     "body-parser": "^1.9.3",
     "classnames": "^1.2.0",


### PR DESCRIPTION
We had pegged Atomizer at 3.0.0 for some reason... changing this to build the latest minor version.