### PR TITLE
Major docs overhaul

### DIFF
--- a/app/configs/menu.js
+++ b/app/configs/menu.js
@@ -28,15 +28,20 @@ export default [
                 routeName: 'helperClasses'
             },
             {
-                label: 'Shorthand',
-                routeName: 'shorthand'
-            },
-            {
-                label: 'The syntax',
+                label: 'Class syntax',
                 routeName: 'syntax'
             },
             {
-                label: 'Atomizer tool',
+                label: 'Shorthand',
+                routeName: 'shorthand'
+            }
+        ]
+    },
+    {
+        category: 'TOOLS',
+        children: [
+            {
+                label: 'Atomizer',
                 routeName: 'atomizer'
             }
         ]

--- a/app/docs/guides/atomic-classes.md
+++ b/app/docs/guides/atomic-classes.md
@@ -1,42 +1,20 @@
 # Atomic classes
 
-Atomic classes ultimately increase the speed of development as they follow a consistent and easy to remember syntax. The inspiration comes from [Emmet](http://emmet.io/), a plugin for many popular text editors which greatly improves HTML & CSS workflow.
+Atomic classes are simple, single-purpose units of styling.  Much like inline styles, Atomic styles only apply a single style declaration.  Unlike inline styles, Atomic styles have a lower specificity, making them easier to override, and can be modified through the use of pseudo-classes, media queries, and more.  
 
-It might take you a short time to get familiar with these class names but as soon as you start using them you'll be at full speed in no time.
+The inspiration for Atomic syntax comes from [Emmet](http://emmet.io/), a plugin for many popular text editors which greatly improves HTML & CSS workflow.
 
-<div class="noteBox info">The [reference page](/reference) lets you quickly search for properties, values, or class names.</div>
+Simple Atomic classes are easily interpreted, since they take a simple value as an parameter.  For example, <code>W(<b class="hljs-string">20px</b>)</code> clearly maps to `width: 20px`, and <code>Lh(<b class="hljs-string">1.5</b>)</code> clearly maps to `line-height: 1.5`.
 
-You use a config object to create the styles you need but you can also *rely on the tool to create many of these styles for you* (to some extend).
+Complex Atomic classes make use of custom identifiers known as "variables", which allow values to be defined in a central location (i.e., the Atomizer configuration file) and reused across styles.  For example, if the variable `foo` is set to `20px`, then `P(foo)` and `M(foo)` would map to `padding: 20px` and `margin: 20px`, respectively.
 
-## Simple classes
+For more on the syntax of Atomic classes and their value parameters, see [the Class Syntax guide](/guides/syntax.html).
 
-These classes are the ones Atomizer can make sense of without the need to check the config object; classes like <code>W(<b class="hljs-string">20px</b>)</code> (`width:20px`), <code>Lh(<b class="hljs-string">1.5</b>)</code> (`line-height:1.5`), etc.
-
-<div class="noteBox info">Examples of color syntax are on the [Atomizer page](/guides/atomizer.html#hexadecimal-colors).</div>
-
-## Custom classes
-
-The value identifier of these classes is mapped to a custom value set in the config object. For example, the following:
-
-```javascript
-'custom': {
-    'Fz(verylarge)': '3em',
-    'P(gutter)': '10px',
-    'C(primary)': 'teal'
-}
-```
-
-creates 3 classes/declarations:
-
-<ul class="ul-list">
-    <li><code>Fz(<b class="hljs-string">verylarge</b>)</code> for `font-size: 3em`</li>
-    <li><code>P(<b class="hljs-string">gutter</b>)</code> for `padding: 10px`</li>
-    <li><code>C(<b class="hljs-string">primary</b>)</code> for `color: teal`</li>
-</ul>
+<div class="noteBox info">The [searchable reference page](/reference) gives you a complete listing of Atomic classes and their supported values.</div>
 
 ## Aliases
 
-Atomic CSS uses aliases for "most" properties [\[1\]](#footnote)<a id="footnote-1" class="D(ib)"></a> that rely on [Functional Notation](http://www.w3.org/TR/css3-values/#functional-notation). Those are the type of component value that can represent more complex types (or invoke special processing).
+Atomic CSS provides aliases for most properties [\[1\]](#footnote)<a id="footnote-1" class="D(ib)"></a> that rely on [Functional Notation](http://www.w3.org/TR/css3-values/#functional-notation):
 
 <table class="Ta(start) W(100%)">
     <caption class="Hidden">Aliases for values based on functional notation</caption>
@@ -170,172 +148,17 @@ Atomic CSS uses aliases for "most" properties [\[1\]](#footnote)<a id="footnote-
     </tbody>
 </table>
 
-<div class="noteBox info">It is possible to apply multiple filters at once by creating a custom value/class in the config object:
+<div class="noteBox info">It is possible to apply multiple filters at once by creating a custom value or class in Atomizer's configuration.  For example:
+
 <pre class="Fs(n)"><code class="lang-javascript"><span class="hljs-string">'custom'</span>: {
     <span class="hljs-string">'Fil(myCustomFilter)'</span>: 'contrast(150%) brightness(10%)'
 }
 </code></pre>
 </div>
 
-## Variables
-
-You can use custom value identifiers to be used as &quot;variables&quot; across different styles. You set such values via the config object, for example:
-
-```javascript
-custom: {
-    "$headerHeight": "20px"
-}
-```
-
-Usage:
-
-```javascript
-<body class="Pt($headerHeight)">
-    <header class="Mih($headerHeight) Pos(f) T(0) Start(0) End(0)">...</header>
-```
-
-Whenever the value of `$headerHeight` changes, the padding of `<body>` stays in sync with the `height` of the `<header>`.
-
-Variables are also an easy way to abstract colors:
-
-```javascript
-custom: {
-    "$primaryColor": "blue",
-    "$secondaryColor": "orange",
-    "$tertiaryColor": "tomato"
-}
-```
-
-Such variables can then be used with any properties that set colors, for example:
-
-<ul class="ul-list">
-    <li>`Bgc($primaryColor)` for `background-color`</li>
-    <li>`C($secondaryColor)` for `color`</li>
-    <li>`Bdc($tertiaryColor)` for `border-color`</li>
-    <li>etc.</li>
-</ul>
-
-Changing any value in the config changes all occurrences in the style sheet.
-
-### Computed values
-
-The config is a JS file, so you can rely on JavaScript to do some math:
-
-```javascript
-var widthOfNav   = 200,
-    widthOfMain  = 600,
-    widthOfRail  = 300,
-    widthOfGutter = 10;
-module.exports = {
-    'custom': {
-        '$nav-width': widthOfNav + 'px',
-        '$main-width': widthOfMain + 'px',
-        '$rail-width': widthOfRail + 'px',
-        '$gutter-width': widthOfGutter + 'px',
-        '$wrapper-width': widthOfNav + widthOfMain + widthOfRail + 2 * widthOfGutter + 'px'
-    }
-};
-```
-
-```html
-<div class="wrapper W($wrapper-width) Mx(a)">
-    <div class="nav W($nav-width) Fl(start)">...</div>
-    <div class="main W($main-width) Fl(start) Mx($gutter-width)">...</div>
-    <div class="rail W($rail-width) Fl(start)">...</div>
-</div>
-```
-
-
-
-## Advanced classes
-
-These classes are mostly contextual; they take into consideration **ancestor nodes** or **media queries**.
-
-### Descendant selectors
-
-You can style a node according to its relationship with its parent or ancestor, for example:
-
-```html
-<p class="foo">The following text is <b class="foo_C(#0b0)">lime</b>.</p>
-```
-<p class="foo">The following text is <b class="foo_C(#0b0)">lime</b>.</p>
-
-Same class on a node outside the scope of `.foo`:
-
-```html
-<p>The following text is <b class="foo_C(#0b0)">lime</b>.</p>
-```
-
-<p>The following text is <b class="foo_C(#0b0)">lime</b>.</p>
-
-<p class="noteBox info"><strong>Practical example</strong>:<br> we use the class `home_D(b)` to style `#main` differently on  [acss.io](http://www.acss.io) home page.</p>
-
-#### pseudo-classes on ancestors
-
-You can use pseudo-classes with classes relying on contextual selectors, for example `ul-list:h>V(h)` hides the direct children of `.ul-list` &mdash; only when users hover over the said list.
-
-```html
-<ul class="ul-list">
-    <li class="ul-list:h>V(h)">List item #1</li>
-    <li class="ul-list:h>V(h)">List item #2</li>
-    <li>List item #3</li>
-</ul>
-```
-
-<ul class="ul-list">
-    <li class="ul-list:h>V(h)">List item #1</li>
-    <li class="ul-list:h>V(h)">List item #2</li>
-    <li>List item #3</li>
-</ul>
-
-<p class="noteBox important">Unlike all other Atomic classes, the ones containing descendant selectors are **not** sandboxed via the namespace (if one is set in the config). Instead, Atomizer adds `!important` to these styles.</p>
-
-### Breakpoints
-
-#### Classes bound to a single breakpoint
-
-Use the config object to create breakpoints then append a modifier (`--<breakpoint name>`) to your Atomic classes so their styling comes into play only within the breakpoint they relate to.
-
-```javascript
-breakPoints: {
-    'sm': '@media(min-width:500px)', // breakpoint 1
-    'md': '@media(min-width:900px)', // breakpoint 2
-    'lg': '@media(min-width:1200px)' // breakpoint 3
-}
-```
-
-<p class="noteBox info">You can choose any name you want for the breakpoints you create via the config object.</p>
-
-The class `P(10px)--sm` will style a box with a `padding` of `10px` inside the `sm` breakpoint while the class `P(20px)--lg` will style a box with a `padding` of `20px` inside the `lg` breakpoint.
-
-#### Classes bound to multiple breakpoints
-
-Use the config object to create breakpoints then associate a custom class to multiple breakpoints so its styling varies within those breakpoints.
-
-```javascript
-'custom': {
-    'P($gutter)': {
-        'default': '10px',
-        'sm': '12px',
-        'md': '14px',
-        'lg': '20px'
-    }
-}
-```
-
-The class `P($gutter)` will style a box with a `padding` of `10px` below the first breakpoint, but then this padding will become:
-
-<ul class="ul-list">
-    <li>`12px` inside the `sm` breakpoint</li>
-    <li>`14px` inside the `md` breakpoint</li>
-    <li>`20px` inside the `lg` breakpoint</li>
-</ul>
-
-More info about [breakpoints and responsive web design](../tutorials/responsive-web-design.html).
-
 <hr class="Mt(50px)">
 
 <ol id="footnote" class="ol-list">
-    <li>We use the function name whenever it is bound to a `property`; for example `Rotate()` for `transform` or `Blur()` for `filter`. However, we do not have yet aliases for `calc()`, `rgba()`, etc. [\[↩\]](#footnote-1).</li>
-    <li>Use the config object to set custom values for `Matrix()` and `Matrix3d()`. [\[↩\]](#footnote-2) [\[↩\]](#footnote-3).</li>
+    <li>Aliases use the function name whenever it is bound to a `property`; for example `Rotate()` for `transform` or `Blur()` for `filter`. However, there are not yet aliases for `calc()`, `rgba()`, etc. [\[↩\]](#footnote-1).</li>
+    <li>Use the Atomizer config object to set custom values for `Matrix()` and `Matrix3d()`. [\[↩\]](#footnote-2).</li>
 </ol>

--- a/app/docs/guides/atomizer.md
+++ b/app/docs/guides/atomizer.md
@@ -1,8 +1,8 @@
 # Atomizer tool
 
-[Atomizer](https://github.com/yahoo/atomizer) is a [npm module](https://www.npmjs.com/package/atomizer) meant to create `atomic.css` &mdash; a style sheet that contains Atomic *and* helper rules.
+[Atomizer](https://github.com/yahoo/atomizer) is a tool ([npm](https://www.npmjs.com/package/atomizer), [github](https://github.com/yahoo/atomizer)) for generating Atomic CSS stylesheets.
 
-Atomizer creates CSS rules based on Atomic classes it finds in documents. This means that styles are always up-to-date *without the need for writing a single CSS declaration* [\[1\]](#footnote)<a id="footnote-1" class="D(ib)"></a>.
+Atomizer creates CSS style declarations based on Atomic classes it finds in your project. This means that your style sheets are always up-to-date *without the need for writing a single CSS declaration manually* [\[1\]](#footnote)<a id="footnote-1" class="D(ib)"></a>.
 
 For example, if your project was a single page containing:
 
@@ -10,7 +10,7 @@ For example, if your project was a single page containing:
 <div class="D(b) Va(t) Fz(20px)">Hello World!</div>
 ```
 
-Atomizer would create a `atomic.css` file containing these rules:
+Atomizer would create a style sheet containing these rules:
 
 ```css
 .D(b) {
@@ -31,7 +31,7 @@ If, for example, you decided to update the classes like below:
 <div class="Va(t) Fz(18px)">Hello World!</div>
 ```
 
-Then Atomizer would update the file (removing `D(b)` and replacing `Fz(20px)` with `Fz(18px)`) to match exactly *what is being used* inside the project:
+Then Atomizer would update the style sheet (removing `D(b)` and replacing `Fz(20px)` with `Fz(18px)`) to match exactly *what is being used* inside the project:
 
 ```css
 .Va(t) {
@@ -42,63 +42,51 @@ Then Atomizer would update the file (removing `D(b)` and replacing `Fz(20px)` wi
 }
 ```
 
-How cool is that? No bloat, no maintenance, no problem.
+## Build Integration
 
-<p class="noteBox info">We have a [grunt task](https://github.com/yahoo/grunt-atomizer) for running Atomizer.</p>
+So how do you integrate Atomizer into your project? You can use Grunt, Gulp, WebPack, Make, Graddle, or any other build system you like.
 
-## This is what you get for free
+For example, if you're using the [Grunt](http://gruntjs.com/) task runner, you can use [grunt-atomizer](http://github.com/yahoo/grunt-atomizer) to configure and execute Atomizer:
 
-You can create any custom class you want via the [config object](https://github.com/yahoo/atomizer/blob/master/examples/example-config.js) but you should follow the <a href="syntax.html">Atomic syntax</a> if you wish Atomizer to recognize the following identifiers and combinators out of the box:
+```javascript
+// use grunt-contrib-watch for changes and run tasks
+watch: {
+    dev: {
+        options: {
+            livereload: true
+        },
+        files: [
+            './examples/**/*.html'
+        ],
+        tasks: ['atomizer']
+    }
+},
+atomizer: {
+    options: {
+        // set a context to increase specificity
+        namespace: '#atomic',
+        // pass a base config file
+        configFile: './config/manual-config.js',
+        // augment classNames in the base config file
+        config: {
+            classNames: ['D(b)']
+        }
+        // the final config file used by the tool will be written
+        // in the following file:
+        configOutput: 'tmp/config.json',
+    },
+    files: [
+        {
+            // parse your project's html files to automatically add 
+            // found Atomic classes to your config
+            src: ['./src/*.html'],
+            // generate the css in the file below
+            dest: './atomic.css'
+        }
+    ]
+}
+```
 
-### Contextual class related to *ancestor*
-
-Use a class attached to *an ancestor*  of the element if you wish to create a contextual style. For example, the class `myBox_D(n)` will hide the node if it is a descendant of an element with the class `myBox` applied to it.
-
-### Contextual class related to *parent*
-
-Use a class attached to *the parent* of the element if you wish to create a contextual style. For example, the class `myBox>D(n)` will hide the node if it is a child of an element with the class `myBox` applied to it.
-
-### Pseudo classes on ancestor
-
-Use a pseudo-class abbreviation to bind your style to that pseudo-class. For example, the class `myBox:h_Td(u)` will underline text when users hover over its ancestor to which the class `.myBox` is applied.
-
-### Pseudo classes on value identifier
-
-Use a pseudo-class abbreviation to bind your style to that pseudo-class. For example, the class `Td(u):h` will underline text on mouseover.
-
-### Units in value identifiers
-
-Use any unit you want (i.e. `W(50%)`, `M(20px)`, `Fz(1em)`, etc.).
-
-### Unit-less values
-
-Use unit-less values to set styles like `line-height` (i.e. `Lh(1.5)`), `font-weight` (i.e. `Fw(500)`), etc.
-
-### Negative values
-
-Use the minus sign (`-`) to set negative values (i.e. `M(-20px)`)
-
-### Multiple values
-
-Pass multiple values using commas (`,`) (i.e. `Bgp(20px,50px)`)
-
-### Hexadecimal colors
-
-Use hexadecimal colors (in *lowercase with the `#`*) as value identifier (i.e. `C(#fff)`) and Atomizer will create the declaration for you (`color:#fff`)
-
-### Hexadecimal colors with alpha
-
-Use hexadecimal colors (in *lowercase with the `#`*) as value identifier followed by the opacity value (i.e. `C(#fff.5)`) and Atomizer will create the declaration for you (`color:rgba(255,255,255,.5)`)
-
-### Fractions
-
-Use any fraction you want (i.e. `W(1/2)`) and Atomizer will create the CSS declaration for you (`width:50%`)
-
-### `!important` directive
-
-Use `!` after the value identifier (i.e. `D(b)!`) and Atomizer will add `!important` to the declaration for you (`display:block!important`)
-
-<div class="noteBox info">The [reference page](/reference) lets you quickly search for properties, values, or class names.</div>
 
 <hr class="Mt(50px)">
 

--- a/app/docs/guides/helper-classes.md
+++ b/app/docs/guides/helper-classes.md
@@ -1,10 +1,12 @@
 # Helper classes
 
-These classes are tailored to help with common styling patterns. You can either use the helpers offered through Atomic or create your own set of helper classes.
+Helper classes are provided to help with common styling patterns. [Atomizer](/guides/atomizer.html) provides the following set of helper classes, and you can define your own through custom Atomizer rulesets.
+
+Unlike [Atomic classes](/guides/atomic-classes.html), helper classes apply multiple style declarations from a single class, but still are intended to provide a low-level, single-purpose unit of style.
 
 ## `Bd*` (Borders)
 
-Styling elements with a border requires 3 properties [\[1\]](#footnote)<a id="footnote-1" class="D(ib)"></a> so to make styling via classes a bit less verbose, we have the following helpers that combine `border-style` (set to `solid`) and `border-width` (set to `1px`):
+Styling elements with a border requires 3 properties [\[1\]](#footnote)<a id="footnote-1" class="D(ib)"></a> so to make styling via classes a bit less verbose, the following helpers combine `border-style` (set to `solid`) and `border-width` (set to `1px`):
 
 <ul class="ul-list">
     <li>`Bd` creates a `1px` border on all edges of a box</li>
@@ -16,7 +18,7 @@ Styling elements with a border requires 3 properties [\[1\]](#footnote)<a id="fo
     <li>`BdStart` creates a `1px` border on the left edge of a box (in a LTR context)</li>
 </ul>
 
-You can combine one of the class above with a `border-color` of your choice (i.e. `Bdc(#ff6347)`) to get a border color different than the text color of the box.
+You can combine one of the classes above with a `border-color` of your choice (i.e. `Bdc(#ff6347)`) to get a border color different than the text color of the box.
 
 Example with a initial border color (and `border-width` set to `1px`):
 
@@ -34,10 +36,10 @@ Example with a custom color:
 
 <p class="Bd Bdc(#ff6347) P(10px)">Lorem ipsum dolor sit amet, id oratio graeco nostrum sit, latine eligendi scribentur mea ex. Tota dolorem voluptua eos at. Ei nec reque viderer facilis. Aliquip necessitatibus ex pri, pertinax atomorum ei sea. Ea omittam appetere posidonium per, te meliore volutpat duo, dolorem ponderum interpretaris sea ut.</p>
 
-<p>We have chosen to set the default `width` of those helpers to be `1px` as it is the most common use case. If you want to use a different `width` or `style` value, then you can either</p>
+<p>The default `width` of these helpers is `1px` as it is the most common use case. If you want to use a different `width` or `style` value, then you can either</p>
 <ul class="ul-list">
-    <li>use a granular approach, for example: `Bdw(5px) Bds(s) Bdc(#555)`</li>
-    <li>create a custom class, for example: `Bd(myCustomBorder)` via the config object</li>
+    <li>use standard Atomic classes, for example: `Bdw(5px) Bds(s) Bdc(#555)`</li>
+    <li>create a custom class via config, for example: `Bd(myCustomBorder)`</li>
     <li>use **the same helper classes** with [different values](helper-classes.htmlthe-special-case-of-border-)</li>
 </ul>
 
@@ -47,7 +49,7 @@ Example with a custom color:
 
 Most authors use `overflow:hidden` to create [block-formatting contexts](http://yuiblog.com/blog/2010/05/19/css-101-block-formatting-contexts/) but such styling may come [with side-effects](http://yuiblog.com/blog/2010/09/27/clearfix-reloaded-overflowhidden-demystified/).
 
-For this reason, we have a helper class called `BfcHack` which creates a block-formatting context that does not &quot;shrinkwrap&quot;. This is something [Nicole Sullivan and Nan Gao](http://www.stubbornella.org/content/2010/12/09/the-hacktastic-zoom-fix/#comment-18394) came up with.
+For this reason, the helper class called `BfcHack` creates a block-formatting context that does not &quot;shrinkwrap&quot;. This is an approach introduced by [Nicole Sullivan and Nan Gao](http://www.stubbornella.org/content/2010/12/09/the-hacktastic-zoom-fix/#comment-18394).
 
 <p class="noteBox warning">Note that this is a hack and may break if the content of the box is too large or if the box is next to floats.</p>
 
@@ -71,7 +73,7 @@ Example:
 
 ## Hiding content from sighted users
 
-Use the class `Hidden` if you want to hide content that should be accessible to screen-readers:
+Use the class `Hidden` if you want to hide content that should still be accessible to screen-readers:
 
 Example:
 
@@ -82,7 +84,7 @@ Example:
 
 ## `IbBox`
 
-Boxes that are part of inline-block constructs must be styled with multiple styles so rather than seting all of those yourself, you can simply use `IbBox` as a "shorthand" for:
+Boxes that are part of inline-block constructs must be styled with multiple styles. Rather than setting all of those yourself, you can simply use `IbBox` as a "shorthand" for:
 
 ```css
 display: inline-block;
@@ -105,9 +107,9 @@ Example:
 
 ## `LineClamp()`
 
-Truncating multiple line of text across browsers is not an easy feat. Authors usually start with `-webkit-line-clamp` + flexbox and then go from there; addressing [weird bug](https://twitter.com/thierrykoblentz/status/443899465842176000) along the way.
+Truncating multiple lines of text in a way that works across browsers is not an easy feat. Authors usually start with `-webkit-line-clamp` + flexbox and then go from there, addressing [weird bugs](https://twitter.com/thierrykoblentz/status/443899465842176000) along the way.
 
-With the help of Atomizer, you can use a class to "pass" 2 parameters:
+With the help of Atomizer, you can use the `LineClamp()` class to "pass" 2 parameters:
 
 <ul class="ul-list">
     <li>the number of lines you want to display</li>
@@ -140,11 +142,11 @@ Example:
     <div class="Fl(end) W(300px) Ta(c) P(10px)">Box-2</div>
 </div>
 
-The background of the wrapper shows which proves the box contains floats.
+The background of the wrapper is visible, which proves the box contains floats.
 
 ## `StretchedBox`
 
-Use the class `StretchedBox` to stretch a box inside its 'containing block' as this class is mapped to the following declarations:
+Use the class `StretchedBox` to stretch a box inside its 'containing block'. This class is mapped to the following declarations:
 
 ```css
 position: absolute;
@@ -167,7 +169,7 @@ This is handy to create boxes with a [intrinsic aspect ratio](http://alistapart.
 
 ## `Zoom`
 
-Use the class `Zoom` if you support old IE and needs to [give a box a layout](http://www.satzansatz.de/cssd/onhavinglayout.html).
+Use the class `Zoom` if you support old versions of IE and need to [give a box a layout](http://www.satzansatz.de/cssd/onhavinglayout.html).
 
 <hr class="Mt(50px)">
 

--- a/app/docs/guides/shorthand-notation.md
+++ b/app/docs/guides/shorthand-notation.md
@@ -1,6 +1,6 @@
 # Shorthand notation
 
-**We do not offer shorthand notation** (i.e. `M(5px,0,0,0)`) because this would increase the number of selectors or declarations in the style sheet (create bloat).
+**Atomic CSS generally does not offer shorthand notation** (e.g., `M(5px,0,0,0)`) because this would increase the number of selectors or declarations in the style sheet (i.e., create bloat.)
 
 For example, `border-width/style/color` can be specified in any order:
 
@@ -13,7 +13,7 @@ For example, `border-width/style/color` can be specified in any order:
     <li>`Bd(#000,solid,1px)`</li>
 </ul>
 
-The above creates 6 different rules for the exact same styling (a *solid 1px black* border). Yes, we could be smart about it and assign all those classes to the **same** declaration.
+The above creates 6 different rules for the exact same styling (a *solid 1px black* border). While the tool could be smart and assign all those classes to the **same** declaration, you'd still end up with more bytes than is necessary:
 
 ```css
 .Bd(1px,solid,#000),
@@ -26,9 +26,7 @@ The above creates 6 different rules for the exact same styling (a *solid 1px bla
 }
 ```
 
-<p class="noteBox info">For the sake of readability, CSS classes on this page *do not* include the escape character (`\`) where it should be needed.</p>
-
-We could also enforce order (i.e. `width/style/color`) to prevent such duplication but we could still have a lot of redundancy, for example classes such as these:
+It would also be possible to enforce order (i.e., `width,style,color`) to prevent such duplication, but you'd still end up with a lot of redundancy. For example:
 
 <ul class="ul-list">
     <li>`Bd(1px,solid,#000)`</li>
@@ -42,12 +40,12 @@ We could also enforce order (i.e. `width/style/color`) to prevent such duplicati
 Would result in:
 
 <ul class="ul-list">
-    <li>4 dupe declarations for `border-width`</li>
-    <li>5 dupe declarations for `border-style`</li>
-    <li>4 dupe declarations for `border-color`</li>
+    <li>4 duplicate declarations for `border-width`</li>
+    <li>5 duplicate declarations for `border-style`</li>
+    <li>4 duplicate declarations for `border-color`</li>
 </ul>
 
-Either dupe declarations or selector grouping:
+...either through duplicate declarations or selector grouping:
 
 ```css
 .Bd(1px,solid,#000),
@@ -73,24 +71,24 @@ Either dupe declarations or selector grouping:
 }
 ```
 
-In our opinion, the extra bytes do not warrant allowing this syntax.
+## Convenience and helper classes
 
-## Kinda shorthand
+### `X`/`Y` notation
 
-Even though we do not allow shorthand notation, many Atomic classes support &quot;`x/y` notation&quot; which applies the same styling on opposite edges. For example:
+Even though Atomic CSS does not allow shorthand notation, many Atomic classes support &quot;`x`/`y` notation&quot; which applies the same styling on opposite edges. For example:
 
 <ul class="ul-list">
     <li>`Mx(a)` for `margin-left:auto; margin-right:auto;`</li>
     <li>`Py(5px)` for `padding-top:5px; padding-bottom:5px;`</li>
 </ul>
 
-## The special case of `border`
+### Border helper classes
 
-When it comes to border styling, initial values exist for `width` and `color` but many authors may still want to set all 3 values: `width`, `color`, and `style`. To make things a bit less verbose, we have a set of [helpers classes for `border`](helper-classes.html#-bd-borders-) that set `style` to `solid` and `width` to `1px` (as a default).
+When it comes to border styling, initial values exist for `width` and `color` but many authors may still want to set all 3 values: `width`, `color`, and `style`. To make things a bit less verbose, Atomic CSS offers a set of [helper classes for borders](helper-classes.html#-bd-borders-) which set `style` to `solid` and `width` to `1px` (as a default).
 
-This allows to use a single class to create a single pixel border that &quot;inherits&quot; text color, or to mix a helper class with a Atomic class for border-color (i.e. `Bd Bdc(#fff)`).
+This allows you to use a single class to create a single pixel border that either &quot;inherits&quot; text color or can be combined with an Atomic class for border-color (e.g., `Bd Bdc(#fff)`).
 
-In case `solid` and `1px` are not the styles of your liking, but you still want to use the same helper classes, then you can simply overwrite those values in your own style sheet &mdash; using the rules below:
+In case `solid` and `1px` are not the default style you'd prefer, but you still want to use the border helper classes, you can simply redefine those classes in your own style sheet, using the rules below:
 
 ```css
 .Bd,
@@ -127,4 +125,4 @@ In case `solid` and `1px` are not the styles of your liking, but you still want 
 }
 ```
 
-<p class="noteBox info">Make sure to add the namespace to those rules in case you have chosen to set one up in your config.</p>
+<p class="noteBox info">If you've chosen to namespace your Atomic classes, be sure to add the namespace to the above rules.</p>

--- a/app/docs/guides/syntax.md
+++ b/app/docs/guides/syntax.md
@@ -1,29 +1,41 @@
-# The syntax
+# Class syntax
 
-Following a *strict* syntax facilitates the task of parsing tools which in turn helps create richer features.<br>
-Adopting a *common* syntax favors better collaboration between teams and projects.
+Atomic and Helper classes follow a strict syntax, which makes the classnames easier to interpret by humans and easier to parse by tools such as Atomizer.
 
-<p class="noteBox info">For the sake of readability, CSS classes on this page *do not* include the escape character (`\`) where it should be needed.</p>
-
-## The building blocks
+## The syntax
 
 <pre>
-[<b class="hljs-type">&lt;context></b>][<b class="hljs-type">:&lt;pseudo-class></b>][<b class="hljs-type">_</b> || <b class="hljs-type">></b> || <b class="hljs-type">+</b>]<b class="Fw(b)">&lt;Style></b>[(<b class="hljs-string">&lt;value>,&lt;value>?,&lt;value>?!</b>)][<b class="hljs-type"><!></b>][<b class="hljs-type">:&lt;pseudo-class></b>][<b class="hljs-type">--&lt;breakpoint_identifier></b>]
+[<b class="hljs-type"><a href="#-lt-context-">&lt;context></a></b>[<b class="hljs-type">:<a href="#-lt-pseudo-">&lt;pseudo></a></b>]<b class="hljs-type"><a href="#-lt-combinator-">&lt;combinator></a></b>]<b class="Fw(b)"><a class="hljs-string" href="#-lt-style-">&lt;Style></a></b>[(<b class="hljs-type"><a href="#-lt-value-">&lt;value></a>,<a href="#-lt-value-">&lt;value></a>?,...</b>)][<b class="hljs-type"><a href="#-lt-">&lt;!></a></b>][<b class="hljs-type"><a href="#-lt-pseudo-">:&lt;pseudo></a></b>][<b class="hljs-type">--<a href="#-lt-breakpoint_identifier-">&lt;breakpoint_identifier></a></b>]
 </pre>
 
-<p class="Pt(20px)">Where:</p>
+At its core, an Atomic or Helper class is represented by a <a href="#-lt-style-">&lt;Style&gt;</a>. 
 
-<h3 class="Bdw(0) Mt(0)">&lt;context></h3>
+Atomic classes typically require one <a href="#-lt-value-">&lt;value&gt;</a>, enclosed in parentheses, though some classes may accept more (eg, the helper class <a href="/guides/helper-classes.html#-lineclamp-">`LineClamp()`</a> accepts two.)  Helper classess may not require a <a href="#-lt-value-">&lt;value&gt;</a>, in which case the parentheses may be omitted.
+
+Optionally, you may prefix the style with a <a href="#-lt-context-">&lt;context></a> class and <a href="#-lt-combinator-">&lt;combinator></a>. The context class may optionally include a <a href="#-lt-pseudo-">&lt;pseudo></a>.
+
+You may also optionally suffix the style with <a href="#-lt-">&lt;!></a> (for `!important`), a <a href="#-lt-pseudo-">&lt;pseudo></a>, and a <a href="#-lt-breakpoint_identifier-">&lt;breakpoint_identifier></a>.
+
+### RTL/LTR
+
+Any occurrence of `left` and `right` keywords or their abbreviated form ala [Emmet](http://docs.emmet.io/cheat-sheet/) (i.e., `l` and `r`) in <a href="#-lt-style-">&lt;Style&gt;</a> or <a href="#-lt-value-">&lt;value&gt;</a>  must be replaced with the keywords `start` and `end`.  Atomizer will automatically translate the CSS output for left-to-right (LTR) or right-to-left (RTL) depending on options passed during execution.
+
+For example, `Mend(2px)` maps to `margin-right: 2px` in a LTR context and `margin-left: 2px` in an RTL context, and `Pstart(1em)` would map to `padding-left: 1em` in a LTR context, etc.
+
+## Syntax Definitions 
+
+### &lt;context>
 
 Optional.
 
-A **class** applied to an ancestor or sibling of the node, depending on the combinator used (see [examples](#examples-)).
+A **class** applied to an ancestor or sibling of the node (see [examples](#examples-)).
 
-### &lt;pseudo-class>
+### &lt;pseudo>
 
 Optional.
 
-A suffix mapped to a [pseudo-classes](https://developer.mozilla.org/en-US/docs/Web/CSS/Pseudo-classes), for example:
+A suffix mapped to a [pseudo-class](https://developer.mozilla.org/en-US/docs/Web/CSS/Pseudo-classes), for example:
+
 <ul>
     <li>`a` for `:active`</li>
     <li>`c` for `:checked`</li>
@@ -31,6 +43,32 @@ A suffix mapped to a [pseudo-classes](https://developer.mozilla.org/en-US/docs/W
     <li>`h` for `:hover`</li>
     <li>etc.</li>
 </ul>
+
+<p class="noteBox info">You can find the complete list of pseudo-classes and their abbreviations in [Atomizer's grammar library](https://github.com/yahoo/atomizer/blob/master/src/lib/grammar.js#L6).</p>
+
+Pseudo-classes may be applied to any regular class or &lt;context&gt; class. For example:
+
+
+#### Regular class
+
+```html
+<div class="foo">
+    <div class="D(n):h"></div>
+</div>
+```
+
+The above creates the following rule:
+
+```css
+.D\(n\)\:h:hover {
+  display: none;
+}
+```
+
+This causes the `display:none` style to be applied to the current element when hovered over.
+
+
+#### Context class
 
 ```html
 <div class="foo">
@@ -46,19 +84,19 @@ The above creates the following rule:
 }
 ```
 
-In other words, this class hides the element whenever its ancestor (`div.foo`) is hovered over.
+This class hides the current element whenever its ancestor (`.foo`) is hovered over.
 
-<p class="noteBox info">You can find the complete list of pseudo-classes and their abbreviations in [grammar.js](https://github.com/yahoo/atomizer/blob/master/src/lib/grammar.js#L6)</p>
+<p class="noteBox info">Pseudo-classes can be chained, eg., `Op(1):h:f`.</p>
 
 <p class="noteBox important">Internet Explorer 7 and below do not accept the use of colons in classnames, and therefore it's not possible to use the pseudo-class syntax with these browsers.</p>
 
-### &lt;combinators>
+### &lt;combinator>
 
-Optional.
+Required if &lt;context&gt; is provided. One of the following may be used:
 
 #### The underscore character (`_`)
 
-Use this to create a contextual style based on the [descendant combinator](http://www.w3.org/wiki/CSS/Selectors/combinators/descendant)
+Use this to create a contextual style based on the [descendant combinator](http://www.w3.org/wiki/CSS/Selectors/combinators/descendant).
 
 
 ```html
@@ -71,7 +109,7 @@ This class hides the element whenever one of its ancestor has the class `foo` at
 
 #### The right angle bracket character (`>`)
 
-Use this to create a contextual style based on the [child combinator](http://www.w3.org/wiki/CSS/Selectors/combinators/child)
+Use this to create a contextual style based on the [child combinator](http://www.w3.org/wiki/CSS/Selectors/combinators/child).
 
 Example:
 
@@ -85,7 +123,7 @@ This class hides the element if its parent has the class `foo` attached to it.
 
 #### The plus sign (`+`)
 
-Use the [adjacent sibling combinator](http://www.w3.org/wiki/CSS/Selectors/combinators/adjacent) to style the element only if its the sibling of a specified element
+Use the [adjacent sibling combinator](http://www.w3.org/wiki/CSS/Selectors/combinators/adjacent) to style only if the sibling of an particular element.
 
 Example:
 
@@ -100,87 +138,97 @@ This class hides the element if its previous sibling has the class `foo` attache
 
 Required.
 
-CSS property or [helper class](helper-classes.html). [Capitalized](http://en.wikipedia.org/wiki/Capitalization) following [Emmet](http://docs.emmet.io/cheat-sheet/) syntax with no separator between words such as dashes or new capitals.
+CSS property or [helper class](helper-classes.html). [Capitalized](http://en.wikipedia.org/wiki/Capitalization) with no separator between words such as dashes or new capitals. 
+
+<p class="noteBox info">Atomic classes generally follow the [Emmet](http://docs.emmet.io/cheat-sheet/) syntax for their naming convention.</p>
 
 ### &lt;value>
 
-Optional for helpers, required for CSS properties.
+Optional for helper classes, required for Atomic classes.
 
 Examples:
 
 ```css
-.Ta(c) {
+.Ta\(c\) {
     text-align: center;
 }
-.M(20px) {
+.M\(20px\) {
     margin: 20px;
 }
 ```
 
-<p class="noteBox info">Note that [shorthand notation](shorthand-notation.html "Shorthand notation would lead to bloat") is not offered for all properties.</p>
+There are three value types: Defined, Literal and Variable
 
-#### Value types
+#### Defined values
 
-There are 4 value types:
+This is the *abbreviation* of a **defined value**. Defined values are valid keywords for any given property. (For example, `inherit` (`inh`), `auto` (`a`), etc.)  Defined values attempt to follow [Emmet syntax](http://docs.emmet.io/cheat-sheet/) as closely as possible.
 
-##### Custom
+ Defined values are enumerated in Atomizer's ruleset, so there is no need to define such values in Atomizer configuration before using such values. 
 
-This is a string of your choosing (i.e. `large`, `title`, etc.). The mapping of such custom class is done via the config object.
-
-Example:
-
-```javascript
-'custom': {
-    'Fz(title)': 'font-size:18px'
-}
-```
-
-Usage:
-
-```html
-<h1 class="Fz(title)"></h1>
-```
-
-##### Variable
-
-A "variable" is mapped to a global value set in the config object. It is different than a custom value as it is *not bound to a property*, for example:
-
-```javascript
-'custom': {
-    '$gutter': '20px'
-}
-```
-
-Usage:
-
-```html
-<div class="M(#gutter) P(#gutter)"></div>
-```
-
-Changing the value of `$gutter` in the config object would change the value of both the `margin` and `padding` &mdash; *as well as the value of any other class using `$gutter`*.
-
-##### Defined
-
-This is the *abbreviation* of a **defined value**. Defined values are valid keywords for any given property. For example `inherit` (`inh`), `auto` (`a`), etc. Atomizer knows about defined values so there is no need to edit the config object before using such value.
-
-##### Literal
-
-Those are strings meant to be used verbatim. `5px`, `20%`, `1/2`, and `#fff` are examples of literals.
-
-<p class="noteBox important">`hex` values for colors must be written in lowercase (i.e. `#0b0`, not `#0B0`).</p>
-
-Any occurrence of `left` and `right` keywords should be replaced with `start` and `end`. <br>
-**Values that are not present in Emmet** should be named using the rules below:
+**Defined values that are not present in Emmet** are named according to the rules below:
 
 <ul class="ul-list">
     <li>Value should be abbreviated with the first letter of the value.</li>
-    <li>If two values share the same initial letter then the next value in alphabetical order is [abbreviated](http://en.wikipedia.org/wiki/Abbreviation), sometimes in [contracted](http://en.wikipedia.org/wiki/Contraction_%28grammar%29) form with no general rule for when it is in this form, it should just follow the same [Emmet CSS Syntax style guide](http://docs.emmet.io/css-abbreviations/).</li>
+    <li>If two values share the same initial letter, then the next value in alphabetical order is [abbreviated](http://en.wikipedia.org/wiki/Abbreviation) in [contracted](http://en.wikipedia.org/wiki/Contraction_%28grammar%29) form.</li>
     <li>If **one value** is composed by two or more words (e.g. `inline-block`) then the first letter of each word should be used with no separator between them (e.g. `inline-block` becomes `ib`, `space-between` becomes `sb`).</li>
-    <li>Valid CSS **number values** should always be followed by its unit if any (e.g. `100%` and `100px`). These numbers can also be represented as keywords such as `top` and `bottom` if it makes sense in the context of the property. Fraction values should be represented with a forward-slash between the numbers as in `1/12` (the forward slash is escaped in CSS).</li>
-    <li>The `inherit` value should always use the keyword `inh` as a special exception because it is available almost globally.</li>
+    <li>The `inherit` value will always use the keyword `inh` as a special exception because it is available almost globally.</li>
 </ul>
 
-<p class="noteBox info">For any occurrences of `left` and `right` keywords or its abbreviated form in [Emmet](http://docs.emmet.io/cheat-sheet/) `l` and `r`, the `start` and `end` keywords should be used respectively. e.g. `Mend` (`margin-right` in a LTR context), `Pstart` (`padding-left` in a LTR context), etc.</p>
+#### Literal values
+
+Literals are strings whose values are not defined in configuration, but rather can be machine-interpreted. `1em`, `5px`, `20%`, `1/2`, and `#fff` are examples of literals.
+
+##### Units in literal values
+
+Use any unit you want (e.g., `W(50%)`, `M(20px)`, `Fz(1em)`).
+
+Valid CSS **number values** must always be followed by its unit if applicable (e.g. `100%` and `100px`). These numbers can also be represented as keywords such as `top` and `bottom` if it makes sense in the context of the property.
+
+##### Unit-less values
+
+Use unit-less values to set styles like `line-height` (e.g., `Lh(1.5)`), `font-weight` (e.g., `Fw(500)`), etc.
+
+##### Negative values
+
+Use the minus sign (`-`) to set negative values (e.g., `M(-20px)`)
+
+##### Hexadecimal colors
+
+Use 3 or 6 character hexadecimal colors with a `#` prefix as a value identifier (e.g., `C(#fff)`).
+
+<p class="noteBox important">`hex` values for colors must be written in lowercase (i.e. `#ccc`, not `#CCC`).</p>
+
+##### Hexadecimal colors with alpha
+
+Use hexadecimal colors as value identifier followed by an opacity suffix (e.g., `C(#fff.5)`).
+
+##### Fractions
+
+Use any fraction you want (e.g., `W(1/2)`) and Atomizer will create the proper CSS declaration for you (e.g., `width: 50%`)
+
+##### Multiple values
+
+Pass multiple values separated by commas (`,`) when supported (e.g., `Bgp(20px,50px)`).
+
+<p class="noteBox important">Remember, this is a CSS class, not a programming language, so you can't leave a space before or after commas!</p>
+
+#### Variable values
+
+A "variable" is mapped to a global value set in the config object. It is different than a custom class as it is *not bound to a property*, for example:
+
+```javascript
+'custom': {
+    'gutter': '20px'
+}
+```
+
+Usage:
+
+```html
+<div class="M(gutter) P(gutter)"></div>
+```
+
+Changing the value of `gutter` in the config object would change the value of both the `margin` and `padding` &mdash; *as well as the value of any other class using `gutter`*.
 
 ### &lt;!>
 
@@ -191,29 +239,15 @@ The `!` character adds `!important` to the style.
 Example:
 
 ```css
-.D(b) {
+.D\(b\) {
     display: block;
 }
-.D(b)! {
+.D\(b\)\! {
     display: block !important;
 }
 ```
 
-### &lt;pseudo-class>
-
-Optional.
-
-A suffix indicating that this class applies to a [pseudo-class](https://developer.mozilla.org/en-US/docs/Web/CSS/Pseudo-classes) only. This should be abbreviated as shown in [atomizer.js](https://github.com/yahoo/atomizer/blob/master/src/atomizer.js#L29).
-
-Example:
-
-```html
-<a href="#" class="Op(0) Op(1):h">...</a>
-```
-
-<p class="noteBox info">Pseudo-classes *can be chained* (i.e. `Op(1):h:f`).</p>
-
-### --&lt;breakpoint_identifier>
+### &lt;breakpoint_identifier>
 
 Optional.
 
@@ -293,7 +327,7 @@ The `width` of the box is `auto` below `500px`, then `50%` between `500px` and `
             <td class="Va-t P(10px)">This sets the color to black with a 50% opacity</td>
         </tr>
         <tr class="BdT Bdc(#0280ae.3)">
-            <th scope="row" class="Va(t) Whs(nw) P(10px)"><code>M(<b class="hljs-string">$bar</b>)</code></th>
+            <th scope="row" class="Va(t) Whs(nw) P(10px)"><code>M(<b class="hljs-string">bar</b>)</code></th>
             <td class="Va-t P(10px)">This applies a "global" value to `margin` [\[2\]](#footnote)<a id="footnote-2" class="D(ib)"></a></td>
         </tr>
         <tr class="BdT Bdc(#0280ae.3)">
@@ -337,15 +371,13 @@ The `width` of the box is `auto` below `500px`, then `50%` between `500px` and `
 
 <div class="noteBox info">The [reference page](/reference) lets you quickly search for properties, values, or class names.</div>
 
-<p class="noteBox info">CSS class selectors contain proper escape character where needed (i.e. `.Td\(u\)\:h`).</p>
-
 <hr class="Mt-50px">
 
 <ol id="footnote" class="ol-list">
-    <li>`Bxs(foo)` is a custom class set in the config object [\[↩\]](#footnote-1).</li>
-    <li>`$bar` is mapped to a custom value that can be used with any relevant styling (i.e. `P($bar)` for `padding`, `H($bar)` for` height`, etc.) [\[↩\]](#footnote-2).</li>
+    <li>`Bxs(foo)` uses a custom variable `foo` set in the config object [\[↩\]](#footnote-1).</li>
+    <li>`bar` is mapped to a custom value that can be used with any relevant styling (i.e. `P(bar)` for `padding`, `H(bar)` for` height`, etc.) [\[↩\]](#footnote-2).</li>
     <li>`start` is mapped to either "left" or "right" depending on the config file [\[↩\]](#footnote-3).</li>
     <li>this class is an [alias](atomic-classes.html) [\[↩\]](#footnote-4).</li>
     <li>this class is a [helper](helper-classes.html) [\[↩\]](#footnote-5).</li>
-    <li>Unlike all other Atomic classes, the ones containing descendant selectors are **not** sandboxed via the namespace (if you have chosen to set one in the config). Instead, Atomizer adds `!important` to these styles [\[↩\]](#footnote-6).</li>
+    <li>Unlike all other Atomic classes, those containing descendant selectors are **not** sandboxed via the namespace (if you have chosen to set one in the config). Instead, Atomizer adds `!important` to these styles [\[↩\]](#footnote-6).</li>
 </ol>

--- a/app/docs/tutorials/responsive-web-design.md
+++ b/app/docs/tutorials/responsive-web-design.md
@@ -1,12 +1,11 @@
 # Responsive Web Design
 
-<p>You can set your **own** breakpoints in the config object and then use Atomic classes scoped to media queries tied to those breakpoints.</p>
-
-<p class="noteBox info">Classes bound to media queries start with 2 dashes (`--`) followed by the breakpoint &quot;name&quot; (i.e. `sm`).</p>
+You can define your breakpoints as media queries in the config object and then apply those breakpoints to your Atomic classes through [the breakpoint suffix](/guides/syntax.html#-lt-breakpoint_identifier-) or automatic breakpoints.
 
 ## Setting up Breakpoints
 
-<p>Pick the names and media queries you want, for example:</p>
+Pick the breakpoint names and media queries you want, for example:
+
 
 ```json
 'breakPoints': {
@@ -16,9 +15,15 @@
 }
 ```
 
-<h3>Atomic classes and Breakpoints</h3>
+Breakpoints may be named anything you want, as long as the characters are valid for use in  classnames.
 
-<p>Append `--<breakpoint name>` to **any** Atomic class to associate that styling to the breakpoint of your choice. For example, `D(b)--sm` and `C(#000)--md` will create rules in the related media queries:</p>
+## Usage
+
+There are two ways to make use of breakpoints in your Atomic classes: explicitly and automatically.
+
+### Explicit Breakpoints
+
+Append `--<breakpoint name>` to any Atomic class to associate that styling with the breakpoint of your choice. For example, `D(b)--sm` and `C(#000)--md` will create the following rules in the related media queries:
 
 ```css
 @media screen and (min-width:380px) {
@@ -34,11 +39,40 @@
 }
 ```
 
-<p class="noteBox info">For the sake of readability, CSS classes on this page *do not* include the escape character (`\`) where it should be needed.</p>
+### Automatic Breakpoints
 
-## Usage
+[Variable values](/guides/syntax.html#variable-values) and [custom classes](/guides/atomic-classes.html#custom-classes) may also be mapped to breakpoints in configuration to simplify the process of applying styles. In this case, you would not be required to use the [breakpoint identifier](/guides/syntax.html#-lt-breakpoint_identifier-) suffix on your class.
 
-<p>Use different classes to see styles being applied in the context of various breakpoints, for example:</p>
+Simply set the value of your variable or custom class identifier to an object containing breakpoint names as the keys:
+
+```javascript
+'custom': {
+    'P(logo)': {
+        'default': '10px',
+        'sm': '12px',
+        'md': '14px',
+        'lg': '20px'
+    },
+    'gutter': {
+        'default': '1em',
+        'sm': '3em'
+    }
+}
+```
+
+In this example, the class `P(logo)` will style a box with a `padding` of `10px` below the first breakpoint, but then this padding will become:
+
+<ul class="ul-list">
+    <li>`12px` inside the `sm` breakpoint</li>
+    <li>`14px` inside the `md` breakpoint</li>
+    <li>`20px` inside the `lg` breakpoint</li>
+</ul>
+
+Likewise, any class that uses the variable `gutter` will receive different values depending on the currently active breakpoint.
+
+## Examples
+
+When using explicit breakpoints, use multiple classes to have styles applied in the context of various breakpoints, for example:
 
 ```html
    <div class="D(ib)--sm W(50%)--sm W(25%)--lg P(20px) Bgc(#0280ae.5)">1</div><!--
@@ -53,7 +87,7 @@
     <li>Above 900px, the boxes are displayed side-by-side, on a single row (`D(ib)--sm` + `W(25%)--lg`)</li>
 </ul>
 
-<p class="noteBox info">The breakpoints for the Pen below have been chosen so you can see the changes within this page. <strong>Give it a try, resize your viewport!</strong></p>
+<p class="noteBox info">The breakpoints for the example below have been chosen so you can see the changes within this page. <strong>Give it a try, resize your viewport!</strong></p>
 
 <h3 class="penResult">Result</h3>
 


### PR DESCRIPTION
Continuing to overhaul our docs... I've moved a lot of stuff around to clarify our Guides, especially. Now most of the nitty-gritty details are in the Syntax page (eg, details on 'values'), and the other pages are left to explain higher-level design and features.  I've also removed a good bit of redundancy to enhance clarity.  Please take a look - I know this is a pretty massive PR and will be hard to follow, unfortunately, so it may be easier to just push this out and then revise from there...

@renatoi @thierryk @redonkulus @3den @dnewcome