### PR TITLE
Fixing and enhancing reference guide for multi-value classes (eg Trfo)

### DIFF
--- a/app/components/Html.jsx
+++ b/app/components/Html.jsx
@@ -60,6 +60,7 @@ var Html = React.createClass({
                     {liveReload}
                 </body>
                 <script dangerouslySetInnerHTML={{__html: this.props.state}}></script>
+                <script src="https://polyfills.yahooapis.com/polyfill.js?features=es5&version=2.1.21"></script>
                 <script src={assets['js/common.js']}></script>
                 <script src={assets['js/main.js']}></script>
                 <script src="https://assets.codepen.io/assets/embed/ei.js" async></script>

--- a/app/components/ReferenceRules.jsx
+++ b/app/components/ReferenceRules.jsx
@@ -137,6 +137,7 @@ var ReferenceRules = React.createClass({
                         var args = recipe.arguments.reduce(function (prevValue, currentValue, currentIndex) {
                             var obj = {};
                             for (var p in prevValue) {
+                                obj[p] = prevValue[p];
                                 for (var c in currentValue) {
                                     var key = p + ',' + c;
                                     obj[key] = [prevValue[p], currentValue[c]]

--- a/app/components/ReferenceRules.jsx
+++ b/app/components/ReferenceRules.jsx
@@ -22,7 +22,23 @@ import {FluxibleMixin} from 'fluxible/addons';
 const styleRegex = new RegExp(/\$(\d+?)/g);
 
 function replaceRTLTokens(str) {
-    return str.replace('__START__', 'left').replace('__END__', 'right');
+    return str.replace(/__START__/g, 'left').replace(/__END__/g, 'right');
+}
+
+function replacePlaceholders(str, values) {
+    if (!Array.isArray(values)) {
+        values = [values];
+    }
+    // Map each value to a placeholder
+    for (var i = 0; i < values.length; i++) {
+        str = str.replace('$'+i, values[i]);
+    }
+    // Use regex to clean up any leftover placeholders
+    return str.replace(styleRegex, '');
+}
+
+function getValueCount(str) {
+    return str.match(styleRegex).length;
 }
 
 /**
@@ -83,17 +99,30 @@ var ReferenceRules = React.createClass({
             if (recipe.type === 'pattern') {
 
                 if (!hasConfig) {
-                    suffix = "<custom-param>";
-                    value = "value";
-                    if (recipe.allowParamToValue) {
-                        suffix = "<value> or " + suffix;
-                    }
+                    var hasMultiValues = false;
                     for (var property in recipe.styles) {
-                        value = recipe.styles[property].replace(styleRegex, value);
+                        var propertyStyle = recipe.styles[property];
+                        var valueCount = getValueCount(propertyStyle);
+                        if (valueCount > 1) {
+                            hasMultiValues = true;
+                            value = [];
+                            for (var vc = 1; vc <= valueCount; vc++) {
+                                value.push('value' + vc);
+                            }
+                        } else {
+                            value = 'value';
+                        }
+                        propertyStyle = replaceRTLTokens(replacePlaceholders(propertyStyle, value));
                         property = replaceRTLTokens(property);
-                        rawDeclarationBlock.push(property + ": " + value);
-                        styledDeclarationBlock.push(<div>{property}: <b className="C(#07f)">{value}</b></div>);
+                        rawDeclarationBlock.push(property + ": " + propertyStyle);
+                        styledDeclarationBlock.push(<div>{property}: <span className="C(#07f)">{propertyStyle}</span></div>);
                     }
+
+                    suffix = "<custom-param>";
+                    if (recipe.allowParamToValue) {
+                        suffix = "<value>" + (hasMultiValues ? "+" : "") + " or " + suffix;
+                    }
+
                     values.push({
                         rawSelector: prefix + "([" + suffix + "])",
                         rawDeclaration: rawDeclarationBlock,
@@ -102,26 +131,38 @@ var ReferenceRules = React.createClass({
                     });
 
                     if (recipe.arguments) {
-                        // We're cheating for now and assuming only a single set of arguments
-                        // for however many params are present.  We currently aren't supporting
-                        // multiple value params in any of our rules, though that could change
-                        // someday.  If that happens, we'll need to rethink how we render the docs
-                        // since we won't want to output every possible combination of valid param
-                        var args = recipe.arguments[0];
+                        
+                        // Reduce the arguments array down to a single object
+                        // containing all possible permutations
+                        var args = recipe.arguments.reduce(function (prevValue, currentValue, currentIndex) {
+                            var obj = {};
+                            for (var p in prevValue) {
+                                for (var c in currentValue) {
+                                    var key = p + ',' + c;
+                                    obj[key] = [prevValue[p], currentValue[c]]
+                                        .reduce(function(a, b) {
+                                      return a.concat(b);
+                                    }, []);
+                                }
+                            }
+                            return obj;
+                        });
+
                         for (var paramKey in args) {
                             var selector = prefix + '(' + paramKey + ')';
                             var value = args[paramKey];
                             rawDeclarationBlock = [];
-                            // styledDeclarationBlock = [];
+                            styledDeclarationBlock = [];
                             for (var property in recipe.styles) {
-                                declaration = property + ": " + recipe.styles[property].replace(styleRegex, value);
-                                rawDeclarationBlock.push(replaceRTLTokens(declaration));
+                                declaration = replaceRTLTokens(property + ": " + replacePlaceholders(recipe.styles[property], value));
+                                rawDeclarationBlock.push(declaration);
+                                styledDeclarationBlock.push(<div>{declaration}</div>);
                             }
                             values.push({
                                 rawSelector: selector, 
                                 rawDeclaration: rawDeclarationBlock,
                                 selector: <b>{selector}</b>, 
-                                declaration: rawDeclarationBlock
+                                declaration: styledDeclarationBlock
                             });
                         }
                     }
@@ -135,7 +176,7 @@ var ReferenceRules = React.createClass({
 
                             if (valueObj && valueObj.declaration) {
                                 for (var property in valueObj.declaration) {
-                                    declaration = replaceRTLTokens(property) + ": " + valueObj.declaration[property];
+                                    declaration = replaceRTLTokens(property + ": " + valueObj.declaration[property]);
                                     rawDeclarationBlock.push(declaration);
                                     styledDeclarationBlock.push(<div>{declaration}</div>);
                                 }


### PR DESCRIPTION
Lots of problems related to multi-value classes in the reference guide. Here's currently what is output for classes such as `Trfo()`:

![trfo-old](https://cloud.githubusercontent.com/assets/60631/11883832/6409047e-a4ca-11e5-916c-a40ef2364f5d.jpg)

* RTL placeholders aren't being removed (`__START__`)
* Classnames don't show that you can pass multiple params
* `<value> or <custom-param>` implies multi-value in declaration, but not in classname syntax

This PR changes the docs to show all the possible permutations of arguments, ala:

![trfo-new](https://cloud.githubusercontent.com/assets/60631/11884066/f7c3d382-a4cb-11e5-8f9c-00f6b15878c0.jpg)
