### PR TITLE
Adding mentions of Atomizer Web tool

### DIFF
--- a/app/components/PageReference.jsx
+++ b/app/components/PageReference.jsx
@@ -14,7 +14,13 @@ class PageReference extends React.Component {
         return (
             <div id="reference" role="main" className="reference-page innerwrapper Mb(50px) Mx(10px) Maw(1000px)--sm Mx(a)--sm W(90%)--sm">
                 <h1>Reference</h1>
-                <p>Use this page to search for Atomic classes. Visit <a href="/guides/syntax.html" aria-label="about the syntax">this one</a> to understand the syntax, <a href="/guides/syntax.html#examples-" aria-label="examples">this one</a> to look at examples, <a href="/guides/atomic-classes.html" aria-label="about custom classes">this one</a> to learn about custom classes, and check <a href="/guides/helper-classes.html" aria-label="about the helpers">this one</a> for helper/utility classes.</p>
+                <p>Use this page to search for Atomic classes.</p> 
+                <p>You can also <a href="/guides/syntax.html" aria-label="about the syntax">learn about the syntax</a>, 
+                   <a href="/guides/syntax.html#examples-" aria-label="examples">look at some examples</a>, 
+                   <a href="/guides/atomic-classes.html" aria-label="about custom classes">learn about custom classes</a>, 
+                   or <a href="/guides/helper-classes.html" aria-label="about the helpers">learn about helper/utility classes</a>.  
+                   There is also <a href="/guides/atomizer.html#web-tools" aria-label="web tools">a handy web tool</a> to help you experiment with Atomizer syntax.
+                </p>
                 <Reference />
             </div>
         );

--- a/app/docs/guides/atomizer.md
+++ b/app/docs/guides/atomizer.md
@@ -42,9 +42,11 @@ Then Atomizer would update the style sheet (removing `D(b)` and replacing `Fz(20
 }
 ```
 
-## Build Integration
+## Integrations
 
-So how do you integrate Atomizer into your project? You can use Grunt, Gulp, WebPack, Make, Graddle, or any other build system you like.
+### Build
+
+So how do you integrate Atomizer into your project? You can use Grunt, Gulp, WebPack, Make, Graddle, or any other task runner/build system you'd like.
 
 Here's a few open source projects we know about:
 
@@ -52,7 +54,9 @@ Here's a few open source projects we know about:
   * Webpack: [atomic-loader](https://www.npmjs.com/package/atomic-loader)
   * Gulp: [gulp-atomizer](https://www.npmjs.com/package/gulp-atomizer)
 
-### Example: Grunt
+If you create your own, please [let us know!](/support.html)
+
+#### Example: Grunt
 
 If you're using the [Grunt](http://gruntjs.com/) task runner, you can use [grunt-atomizer](http://github.com/yahoo/grunt-atomizer) to configure and execute Atomizer:
 
@@ -95,6 +99,9 @@ atomizer: {
 }
 ```
 
+### Web Tools
+
+For a simple web interface to help you learn about Atomizer and Atomic CSS, check out <a href="https://pankajparashar.com/atomizer-web/">ATOMIZER WEB</a>, a tool built by <a href="https://twitter.com/pankajparashar" title="@pankajparashar on Twitter">Pankaj Parashar</a>. Paste some markup or Atomic classes and ATOMIZER WEB will show you the rendered CSS. The tool also gives you access to the configuration where you can set your own break-points, variables, and more.
 
 <hr class="Mt(50px)">
 


### PR DESCRIPTION
I've added the Atomizer Web stuff over on the Atomizer doc page, and left a link to it in the top of the Reference page.  This replaces PR #103.

fyi @thierryk @pankajparashar

Sorry this one took so long!